### PR TITLE
[BACKPORT][V4] Do not terminate nfs-ganesha after failing to access recovery backend

### DIFF
--- a/src/SAL/recovery/recovery_longhorn.c
+++ b/src/SAL/recovery/recovery_longhorn.c
@@ -426,7 +426,9 @@ static int longhorn_recov_init(void)
 		&response, &response_size);
 	PTHREAD_RWLOCK_unlock(&recov_lock);
 	if (res != 0) {
-		LogFatal(COMPONENT_CLIENTID, "HTTP call error: res=%d (%s)", res, response);
+		LogEvent(COMPONENT_CLIENTID,
+			"Failed to initialize recovery backend. "
+			"HTTP call error: res=%d (%s)", res, response);
 		return -EINVAL;
 	}
 
@@ -462,7 +464,9 @@ static void longhorn_recov_end_grace(void)
 	res = http_call(HTTP_PUT, url, payload, strlen(payload) + 1, &response, &response_size);
 	PTHREAD_RWLOCK_unlock(&recov_lock);
 	if (res != 0) {
-		LogFatal(COMPONENT_CLIENTID, "HTTP call error: res=%d (%s)", res, response);
+		LogEvent(COMPONENT_CLIENTID,
+			"Failed to end grace period in recovery backend. "
+			"HTTP call error: res=%d (%s)", res, response);
 	}
 }
 
@@ -511,7 +515,9 @@ static void longhorn_add_clid(nfs_client_id_t *clientid)
 	res = http_call(HTTP_PUT, url, payload, strlen(payload) + 1, &response, &response_size);
 	PTHREAD_RWLOCK_unlock(&recov_lock);
 	if (res != 0) {
-		LogFatal(COMPONENT_CLIENTID, "HTTP call error: res=%d (%s)", res, response);
+		LogEvent(COMPONENT_CLIENTID,
+			"Failed to create client in recovery backend. "
+			"HTTP call error: res=%d (%s)", res, response);
 	}
 
 	curl_easy_cleanup(curl);
@@ -559,7 +565,9 @@ static void longhorn_rm_clid(nfs_client_id_t *clientid)
 	res = http_call(HTTP_DELETE, url, NULL, 0, &response, &response_size);
 	PTHREAD_RWLOCK_unlock(&recov_lock);
 	if (res != 0) {
-		LogFatal(COMPONENT_CLIENTID, "HTTP call error: res=%d (%s)", res, response);
+		LogEvent(COMPONENT_CLIENTID,
+			"Failed to remove client in recovery backend. "
+			"HTTP call error: res=%d (%s)", res, response);
 	}
 
 	curl_easy_cleanup(curl);
@@ -636,7 +644,9 @@ static void longhorn_read_recov_clids(nfs_grace_start_t *gsp,
 	res = http_call(HTTP_GET, url, NULL, 0, &response, &response_size);
 	PTHREAD_RWLOCK_unlock(&recov_lock);
 	if (res != 0) {
-		LogFatal(COMPONENT_CLIENTID, "HTTP call error: res=%d (%s)", res, response);
+		LogEvent(COMPONENT_CLIENTID,
+			"Failed to read clients from recovery backend. "
+			"HTTP call error: res=%d (%s)", res, response);
 		return;
 	}
 
@@ -700,7 +710,9 @@ static void longhorn_add_revoke_fh(nfs_client_id_t *delr_clid, nfs_fh4 *delr_han
 	res = http_call(HTTP_PUT, url, payload, strlen(payload) + 1, &response, &response_size);
 	PTHREAD_RWLOCK_unlock(&recov_lock);
 	if (res != 0) {
-		LogFatal(COMPONENT_CLIENTID, "HTTP call error: res=%d (%s)", res, response);
+		LogEvent(COMPONENT_CLIENTID,
+			"Failed to add revoke fh in recovery backend. "
+			"HTTP call error: res=%d (%s)", res, response);
 	}
 
 	curl_easy_cleanup(curl);


### PR DESCRIPTION
Avoid terminating the nfs-ganesha when it fails to access the recovery backend. Terminating nfs-ganesha can result in NFS clients becoming stuck.

Longhorn/longhorn#8345




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
