### PR TITLE
nfs4_op_open.c: retry_open_file open upgrade bad perms to fsal_reopen2

### DIFF
--- a/src/Protocols/NFS/nfs4_op_open.c
+++ b/src/Protocols/NFS/nfs4_op_open.c
@@ -1026,14 +1026,11 @@ retry_open_file:
 		/* We need an extra reference below. */
 		file_obj->obj_ops->get_ref(file_obj);
 	} else {
-		old_openflags =
-			file_obj->obj_ops->status2(file_obj, *file_state);
-
 		/* Open upgrade */
 		LogFullDebug(COMPONENT_STATE, "Calling reopen2");
 
 		status = fsal_reopen2(file_obj, *file_state,
-				      openflags | old_openflags, true);
+				      openflags, true);
 
 		if (FSAL_IS_ERROR(status)) {
 			res_OPEN4->status = nfs4_Errno_status(status);


### PR DESCRIPTION
Git clones are failing due to a reopen issue distilled down to:

```sh
exec 7<>reopentest; chmod 0444 reopentest; echo data >&7; exec 8<reopentest ; exec 8>&- ; exec 7>&- ; rm reopentest
```

Since we now pass check_open_permission flag as true to fsal_reopen2 the openflags |'d with old openflags is no longer correct:

Prior:

```
nfs-ganesha-19882[svc_9] open4_ex :STATE :F_DBG :Calling reopen2
nfs-ganesha-19882[svc_9] mdcache_getattrs :RW LOCK :F_DBG :Got read lock on 0xffff5c0042d0 (&entry->attr_lock) at ./FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c:995
nfs-ganesha-19882[svc_9] mdcache_getattrs :RW LOCK :F_DBG :Unlocked 0xffff5c0042d0 (&entry->attr_lock) at ./FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c:1043
nfs-ganesha-19882[svc_9] mdcache_getattrs :MDCACHE :F_DBG :attrs  obj attributes Request Mask=00000680 Valid Mask=0011dfce Supported Mask=0091dfce REGULAR_FILE numlinks=0x1 size=0x0 mode=0444 owner=0xfffffffe group=0xfffffffe atime=09/01/2025 22:39:33 mtime=09/01/2025 22:39:33
nfs-ganesha-19882[svc_9] fsal_check_access_no_acl :NFS4 ACL :F_DBG :file Mode=0444, file uid=4294967294, file gid= 4294967294, user uid=4294967294, user gid= 4294967294, access_type=0X6000000
nfs-ganesha-19882[svc_9] fsal_check_access_no_acl :NFS4 ACL :F_DBG :Using owner mode 0400
nfs-ganesha-19882[svc_9] fsal_check_access_no_acl :NFS4 ACL :F_DBG :Mask=0X4000000, Access Type=0X6000000 Allowed=0X4000000 Denied=0X2000000 DENIED
nfs-ganesha-19882[svc_9] check_open_permission :FSAL :DEBUG :test_access got Permission denied
nfs-ganesha-19882[svc_9] fsal_reopen2 :FSAL :DEBUG :Not re-opening file fsal_access failed with WRITE_ACCESS - Permission denied
```

After:

```
nfs-ganesha-21242[svc_6] open4_ex :STATE :F_DBG :Calling reopen2
nfs-ganesha-21242[svc_6] mdcache_getattrs :RW LOCK :F_DBG :Got read lock on 0xffff6c00b100 (&entry->attr_lock) at ./FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c:995
nfs-ganesha-21242[svc_6] mdcache_getattrs :RW LOCK :F_DBG :Unlocked 0xffff6c00b100 (&entry->attr_lock) at ./FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c:1043
nfs-ganesha-21242[svc_6] mdcache_getattrs :MDCACHE :F_DBG :attrs  obj attributes Request Mask=00000680 Valid Mask=0011dfce Supported Mask=0091dfce REGULAR_FILE numlinks=0x1 size=0x5 mode=0444 owner=0xfffffffe group=0xfffffffe atime=10/01/2025 18:56:23 mtime=10/01/2025 18:56:23
nfs-ganesha-21242[svc_6] fsal_check_access_no_acl :NFS4 ACL :F_DBG :file Mode=0444, file uid=4294967294, file gid= 4294967294, user uid=4294967294, user gid= 4294967294, access_type=0X4000000
nfs-ganesha-21242[svc_6] fsal_check_access_no_acl :NFS4 ACL :F_DBG :Using owner mode 0400
nfs-ganesha-21242[svc_6] fsal_check_access_no_acl :NFS4 ACL :F_DBG :Mask=0X4000000, Access Type=0X4000000 Allowed=0X4000000 Denied=0X0 ALLOWED
```

Change-Id: I9b58f56a2983eebe8482b16e47fd786b96b93b13




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
